### PR TITLE
Improve handling of `ref` parameters in analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -93,14 +93,14 @@ csharp_style_var_for_built_in_types = true
 csharp_style_var_when_type_is_apparent = true
 
 # Expression-bodied members
-csharp_style_expression_bodied_accessors = true
-csharp_style_expression_bodied_constructors = true
-csharp_style_expression_bodied_indexers = true
-csharp_style_expression_bodied_lambdas = true
-csharp_style_expression_bodied_local_functions = true
-csharp_style_expression_bodied_methods = true
-csharp_style_expression_bodied_operators = true
-csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true
@@ -121,13 +121,13 @@ csharp_style_prefer_readonly_struct = true
 csharp_style_prefer_readonly_struct_member = true
 
 # Code-block preferences
-csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
-csharp_prefer_system_threading_lock = true
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
 csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_method_group_conversion = true
-csharp_style_prefer_primary_constructors = true
-csharp_style_prefer_top_level_statements = true
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true
@@ -147,7 +147,7 @@ csharp_style_unused_value_assignment_preference = discard_variable
 csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace
+csharp_using_directive_placement = outside_namespace:silent
 
 # New line preferences
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
@@ -244,3 +244,20 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+[*.{cs,vb}]
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion

--- a/src/Analyzers/Analyzers.CodeFixes/RefParameterAnalyzerCodeFixProvider.cs
+++ b/src/Analyzers/Analyzers.CodeFixes/RefParameterAnalyzerCodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -11,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
 
 
 namespace Acnutech.Analyzers
@@ -66,88 +68,112 @@ namespace Acnutech.Analyzers
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclarationSyntax, cancellationToken);
 
-            int refParameterIndex = methodDeclarationSyntax.ParameterList.Parameters.IndexOf(parameterSyntax);
-
             var methodReferences = await SymbolFinder.FindReferencesAsync(methodSymbol, document.Project.Solution, cancellationToken);
-            var methodReferencesByDocument =
+            var allReferencesByDocument =
                 methodReferences
                 .SelectMany(r => r.Locations.Select(l => (DocumentId: l.Document.Id, l.Location.SourceSpan)))
                 .Append((DocumentId: document.Id, SourceSpan: parameterSyntax.Span))
                 .GroupBy(l => l.DocumentId, l => l.SourceSpan);
 
+            var refParameterInfo = new RefParameterInfo(
+                document.Id,
+                parameterSyntax.Span.Start,
+                methodDeclarationSyntax.ParameterList.Parameters.IndexOf(parameterSyntax));
+
             var solution = document.Project.Solution;
 
-            foreach (var documentGroup in methodReferencesByDocument)
+            foreach (var documentGroup in allReferencesByDocument)
             {
-                var referenceDocument = solution.GetDocument(documentGroup.Key);
-                if (referenceDocument == null)
-                {
-                    continue;
-                }
-
-                var documentEditor = await DocumentEditor.CreateAsync(referenceDocument, cancellationToken);
-                var referenceRoot = await referenceDocument.GetSyntaxRootAsync(cancellationToken);
-
-                var spansInEditOrder = documentGroup
-                    .OrderByDescending(sp => sp.Start);
-
-                foreach (var span in spansInEditOrder)
-                {
-                    var node = referenceRoot.FindNode(span);
-
-                    if (referenceDocument.Id == document.Id && span.Start == parameterSyntax.Span.Start)
-                    {
-                        var parameterSyntax1 = (ParameterSyntax)node;
-
-                        var parameterTrivia = GetTriviaAfterNodeRemoval(refModifier, parameterSyntax1.Type.GetLeadingTrivia());
-
-                        var newParameter = parameterSyntax1.WithModifiers(SyntaxFactory.TokenList())
-                            .WithType(parameterSyntax.Type.WithLeadingTrivia(parameterTrivia))
-                            .WithAdditionalAnnotations(Formatter.Annotation);
-
-                        documentEditor.ReplaceNode(parameterSyntax, newParameter);
-                    }
-                    else
-                    {
-                        var invocationExpression = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
-
-                        var arguments = invocationExpression.ArgumentList.Arguments;
-                        if (arguments.Count <= refParameterIndex)
-                        {
-                            continue;
-                        }
-
-                        var argument = arguments[refParameterIndex];
-
-                        if (argument.RefKindKeyword.Kind() != SyntaxKind.RefKeyword
-                            || !(argument.Expression is IdentifierNameSyntax identifier))
-                        {
-                            continue;
-                        }
-
-                        var trivia = GetTriviaAfterNodeRemoval(argument.RefKindKeyword, identifier.Identifier.LeadingTrivia);
-
-                        var argumentWithoutRef =
-                            argument
-                                .WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.None))
-                                .WithLeadingTrivia(trivia)
-                                .WithAdditionalAnnotations(Formatter.Annotation);
-
-                        documentEditor.ReplaceNode(
-                            invocationExpression,
-                            invocationExpression.WithArgumentList(
-                                invocationExpression.ArgumentList.ReplaceNode(
-                                    argument,
-                                    argumentWithoutRef)));
-                    }
-
-                    var updatedDocument1 = documentEditor.GetChangedDocument();
-                    var formattedDocument = await Formatter.FormatAsync(updatedDocument1, Formatter.Annotation, cancellationToken: cancellationToken);
-                    solution = formattedDocument.Project.Solution;
-                }
+                solution = await UpdateDocument(solution, documentGroup.Key, documentGroup.Select(dg => dg), refParameterInfo, cancellationToken);
             }
 
             return solution;
+        }
+
+        private static async Task<Solution> UpdateDocument(
+            Solution solution,
+            DocumentId documentId,
+            IEnumerable<TextSpan> spans,
+            RefParameterInfo refParameterInfo,
+            CancellationToken cancellationToken)
+        {
+            var referenceDocument = solution.GetDocument(documentId);
+            if (referenceDocument == null)
+            {
+                return solution;
+            }
+
+            var documentEditor = await DocumentEditor.CreateAsync(referenceDocument, cancellationToken);
+            var documentSyntaxRoot = await referenceDocument.GetSyntaxRootAsync(cancellationToken);
+
+            var spansInEditOrder = spans
+                .OrderByDescending(sp => sp.Start);
+
+            foreach (var span in spansInEditOrder)
+            {
+                var node = documentSyntaxRoot.FindNode(span);
+
+                if (referenceDocument.Id == refParameterInfo.DocumentId && span.Start == refParameterInfo.ParameterSyntaxSpanStart)
+                {
+                    UpdateRefParameter(documentEditor, node);
+                }
+                else
+                {
+                    UpdateRefArgument(documentEditor, node, refParameterInfo.RefParameterIndex);
+                }
+            }
+
+            var updatedDocument1 = documentEditor.GetChangedDocument();
+            var formattedDocument = await Formatter.FormatAsync(updatedDocument1, Formatter.Annotation, cancellationToken: cancellationToken);
+            return formattedDocument.Project.Solution;
+        }
+
+        private static void UpdateRefParameter(DocumentEditor documentEditor, SyntaxNode node)
+        {
+            var parameterSyntax1 = (ParameterSyntax)node;
+
+            var refModifier1 = parameterSyntax1.Modifiers[0];
+            var parameterTrivia = GetTriviaAfterNodeRemoval(refModifier1, parameterSyntax1.Type.GetLeadingTrivia());
+
+            var newParameter = parameterSyntax1.WithModifiers(SyntaxFactory.TokenList())
+                .WithType(parameterSyntax1.Type.WithLeadingTrivia(parameterTrivia))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            documentEditor.ReplaceNode(node, newParameter);
+        }
+
+        private static void UpdateRefArgument(DocumentEditor documentEditor, SyntaxNode node, int refParameterIndex)
+        {
+            var invocationExpression = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
+            var arguments = invocationExpression.ArgumentList.Arguments;
+            if (arguments.Count <= refParameterIndex)
+            {
+                return;
+            }
+
+            var argument = arguments[refParameterIndex];
+
+            if (argument.RefKindKeyword.Kind() != SyntaxKind.RefKeyword
+                || !(argument.Expression is IdentifierNameSyntax identifier))
+            {
+                return;
+            }
+
+            var trivia = GetTriviaAfterNodeRemoval(argument.RefKindKeyword, identifier.Identifier.LeadingTrivia);
+
+            var argumentWithoutRef =
+                argument
+                    .WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.None))
+                    .WithLeadingTrivia(trivia)
+                    .WithAdditionalAnnotations(Formatter.Annotation);
+
+            documentEditor.ReplaceNode(
+                invocationExpression,
+                invocationExpression.WithArgumentList(
+                    invocationExpression.ArgumentList.ReplaceNode(
+                        argument,
+                        argumentWithoutRef)));
         }
 
         private static SyntaxTriviaList GetTriviaAfterNodeRemoval(SyntaxToken removedNode, SyntaxTriviaList nextLeadingTrivia)
@@ -161,5 +187,19 @@ namespace Acnutech.Analyzers
                 && trivia[0].ToString() == " "
                 ? SyntaxFactory.TriviaList()
                 : trivia;
+
+        private struct RefParameterInfo
+        {
+            public RefParameterInfo(DocumentId documentId, int parameterSyntaxSpanStart , int refParameterIndex)
+            {
+                DocumentId = documentId;
+                ParameterSyntaxSpanStart = parameterSyntaxSpanStart;
+                RefParameterIndex = refParameterIndex;
+            }
+
+            public DocumentId DocumentId { get; }
+            public int ParameterSyntaxSpanStart { get; }
+            public int RefParameterIndex { get; }
+        }
     }
 }

--- a/src/Analyzers/Analyzers.Test/RefParameterAnalyzerUnitTests.cs
+++ b/src/Analyzers/Analyzers.Test/RefParameterAnalyzerUnitTests.cs
@@ -107,7 +107,7 @@ namespace Acnutech.RefParameterAnalyzer.Test
     {
         class Test
         {
-            void MethodA(int a, 
+            void MethodA(int a,
                          int b,
                          int c) {}
 
@@ -150,7 +150,7 @@ namespace Acnutech.RefParameterAnalyzer.Test
     {
         class Test
         {
-            void MethodA(int a, 
+            void MethodA(int a,
                           /*a*/int b,
                          int c) {}
 
@@ -159,6 +159,43 @@ namespace Acnutech.RefParameterAnalyzer.Test
                 int b = 0;
                 MethodA(1,
                     /*d*//*c*/ b, 3);
+            }
+        }
+    }";
+
+            var expected = VerifyCS.Diagnostic("ACNU0001").WithLocation(0).WithArguments("b");
+            await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
+        }
+
+        [TestMethod]
+        public async Task FormatModifiedFragments()
+        {
+            var test = /* lang=c#-test */@"
+    namespace ConsoleApplication1
+    {
+        class Test
+        {
+            void MethodA(int a,  {|#0:ref|}  int b, int c) {}
+
+            void MethodB()
+            {
+                int b = 0;
+                MethodA(1,  ref  b, 3);
+            }
+        }
+    }";
+
+            var fixtest = /* lang=c#-test */@"
+    namespace ConsoleApplication1
+    {
+        class Test
+        {
+            void MethodA(int a, int b, int c) {}
+
+            void MethodB()
+            {
+                int b = 0;
+                MethodA(1, b, 3);
             }
         }
     }";

--- a/src/Analyzers/Analyzers.Test/RefParameterAnalyzerUnitTests.cs
+++ b/src/Analyzers/Analyzers.Test/RefParameterAnalyzerUnitTests.cs
@@ -125,6 +125,49 @@ namespace Acnutech.RefParameterAnalyzer.Test
         }
 
         [TestMethod]
+        public async Task PreserveTrivia()
+        {
+            var test = /* lang=c#-test */@"
+    namespace ConsoleApplication1
+    {
+        class Test
+        {
+            void MethodA(int a, 
+                         {|#0:ref|} /*a*/int b,
+                         int c) {}
+
+            void MethodB()
+            {
+                int b = 0;
+                MethodA(1,
+                    /*d*/ref/*c*/ b, 3);
+            }
+        }
+    }";
+
+            var fixtest = /* lang=c#-test */@"
+    namespace ConsoleApplication1
+    {
+        class Test
+        {
+            void MethodA(int a, 
+                          /*a*/int b,
+                         int c) {}
+
+            void MethodB()
+            {
+                int b = 0;
+                MethodA(1,
+                    /*d*//*c*/ b, 3);
+            }
+        }
+    }";
+
+            var expected = VerifyCS.Diagnostic("ACNU0001").WithLocation(0).WithArguments("b");
+            await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
+        }
+
+        [TestMethod]
         public async Task UpdateMultipleReferencesToChangedMethod()
         {
             var test = /* lang=c#-test */@"

--- a/src/Analyzers/Analyzers/RefParameterAnalyzer.cs
+++ b/src/Analyzers/Analyzers/RefParameterAnalyzer.cs
@@ -40,8 +40,13 @@ namespace Acnutech.Analyzers
             //Debugger.Break();
             // https://github.com/PacktPublishing/Roslyn-Cookbook/blob/master/Chapter03/CodeSamples/Recipe%204%20-%20CodeRefactoringProvider/CodeRefactoring.zip
             ParameterSyntax parameterSyntax = (ParameterSyntax)context.Node;
-            var pos = parameterSyntax.Modifiers.IndexOf(SyntaxKind.RefKeyword);
-            if (pos < 0)
+            if(parameterSyntax.Modifiers.Count != 1)
+            {
+                return;
+            }
+
+            var refModifier = parameterSyntax.Modifiers[0];
+            if (refModifier.Kind() != SyntaxKind.RefKeyword)
             {
                 return;
             }
@@ -75,7 +80,7 @@ namespace Acnutech.Analyzers
                     return;
                 }
 
-                context.ReportDiagnostic(Diagnostic.Create(Rule, parameterSyntax.Modifiers[pos].GetLocation(), parameterSyntax.Identifier.Text));
+                context.ReportDiagnostic(Diagnostic.Create(Rule, refModifier.GetLocation(), parameterSyntax.Identifier.Text));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Enhanced code-fix to handle multiple references in a single file.
- Preserved indentation and comments around removed `ref` modifiers, ensuring proper formatting.
- Refactored code-fix logic for simplicity and maintainability.
- Restricted analyzer to apply changes only in safe contexts.
- Updated `.editorconfig` with new settings for coding styles and naming conventions.