### PR TITLE
Minor fixes

### DIFF
--- a/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -61,11 +61,20 @@ namespace Acnutech.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert ref to out parameter.
+        /// </summary>
+        internal static string ConvertRefToOutParameterCodeFixTitle {
+            get {
+                return ResourceManager.GetString("ConvertRefToOutParameterCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove the ref modifier.
         /// </summary>
-        internal static string CodeFixTitle {
+        internal static string RemoveRefModifierCodeFixTitle {
             get {
-                return ResourceManager.GetString("CodeFixTitle", resourceCulture);
+                return ResourceManager.GetString("RemoveRefModifierCodeFixTitle", resourceCulture);
             }
         }
     }

--- a/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.resx
@@ -117,8 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CodeFixTitle" xml:space="preserve">
+  <data name="RemoveRefModifierCodeFixTitle" xml:space="preserve">
     <value>Remove the ref modifier</value>
+    <comment>The title of the code fix.</comment>
+  </data>
+  <data name="ConvertRefToOutParameterCodeFixTitle" xml:space="preserve">
+    <value>Convert ref to out parameter</value>
     <comment>The title of the code fix.</comment>
   </data>
 </root>

--- a/src/Analyzers/Analyzers.CodeFixes/ConvertRefToOutParameterCodeFixProvider.cs
+++ b/src/Analyzers/Analyzers.CodeFixes/ConvertRefToOutParameterCodeFixProvider.cs
@@ -16,9 +16,9 @@ namespace Acnutech.Analyzers
             get { return ImmutableArray.Create(RefParameterAnalyzer.ConvertRefToOutParameterDiagnostic.Id); }
         }
 
-        protected override string Title => "aa";
+        protected override string Title => CodeFixResources.ConvertRefToOutParameterCodeFixTitle;
 
-        protected override string EquivalenceKey => "bgb";
+        protected override string EquivalenceKey => nameof(CodeFixResources.ConvertRefToOutParameterCodeFixTitle);
 
         protected override void UpdateRefParameter(DocumentEditor documentEditor, SyntaxNode node)
         {

--- a/src/Analyzers/Analyzers.CodeFixes/RemoveUnnecessaryRefModifierCodeFixProvider.cs
+++ b/src/Analyzers/Analyzers.CodeFixes/RemoveUnnecessaryRefModifierCodeFixProvider.cs
@@ -17,9 +17,9 @@ namespace Acnutech.Analyzers
             get { return ImmutableArray.Create(RefParameterAnalyzer.RemoveUnnecessaryRefModifierDiagnostic.Id); }
         }
 
-        protected override string Title => CodeFixResources.CodeFixTitle;
+        protected override string Title => CodeFixResources.RemoveRefModifierCodeFixTitle;
 
-        protected override string EquivalenceKey => nameof(CodeFixResources.CodeFixTitle);
+        protected override string EquivalenceKey => nameof(CodeFixResources.RemoveRefModifierCodeFixTitle);
 
         protected override void UpdateRefParameter(DocumentEditor documentEditor, SyntaxNode node)
         {

--- a/src/Analyzers/Analyzers.Test/Analyzers.Test.csproj
+++ b/src/Analyzers/Analyzers.Test/Analyzers.Test.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="1.1.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Analyzers/Analyzers.Vsix/Analyzers.Vsix.csproj
+++ b/src/Analyzers/Analyzers.Vsix/Analyzers.Vsix.csproj
@@ -2,7 +2,7 @@
 <Project>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Acnutech.Analyzers.Vsix</RootNamespace>
     <AssemblyName>Analyzers.Vsix</AssemblyName>
   </PropertyGroup>

--- a/src/Analyzers/Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/Analyzers/AnalyzerReleases.Shipped.md
@@ -12,4 +12,4 @@ ACNU0001 |  Usage   |  Warning | RemoveUnnecessaryRefModifier, [Documentation](R
 
 Rule ID  | Category | Severity | Notes
 ---------|----------|----------|--------------------
-ACNU0002 |  Usage   |  Warning | ConvertRefToOutParameter, [Documentation](ConvertRefToOutParameterDiagnostic)
+ACNU0002 |  Usage   |  Info    | ConvertRefToOutParameter, [Documentation](ConvertRefToOutParameterDiagnostic)

--- a/src/Analyzers/Analyzers/RefParameterAnalyzer.cs
+++ b/src/Analyzers/Analyzers/RefParameterAnalyzer.cs
@@ -36,7 +36,7 @@ namespace Acnutech.Analyzers
             private const string Category = "Usage";
 
             internal static readonly DiagnosticDescriptor Rule
-                = new DiagnosticDescriptor(Id, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+                = new DiagnosticDescriptor(Id, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
         }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics


### PR DESCRIPTION
- Changed severity of ConvertRefToOutParameter diagnostic to info
- Fixed the title of the ConvertRefToOutParameter code fix provider
- Added a reference to System.Formats.Asn1 to remove dependency on vulnerable package
- Changed the target framework of the VSIX project to .net8.0 to align with VS20222.