### PR TITLE
Redundant Convert.To analyzer

### DIFF
--- a/src/Acnutech.Analyzers.sln
+++ b/src/Acnutech.Analyzers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.35821.62 d17.14
+VisualStudioVersion = 17.14.35821.62
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzers", "Analyzers\Analyzers\Analyzers.csproj", "{9F7E1214-856E-49AF-A9A0-DDF9A45338B8}"
 EndProject
@@ -12,6 +12,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzers.Test", "Analyzers\Analyzers.Test\Analyzers.Test.csproj", "{759A9B0A-438E-452D-A2E1-89E103D67CB4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzers.Vsix", "Analyzers\Analyzers.Vsix\Analyzers.Vsix.csproj", "{EAB559CC-6AD8-48A5-803D-39546E9CB022}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -88,6 +88,15 @@ namespace Acnutech.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove redundant Convert.To method.
+        /// </summary>
+        internal static string RedundantConvertCodeFixTitle {
+            get {
+                return ResourceManager.GetString("RedundantConvertCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove the ref modifier.
         /// </summary>
         internal static string RemoveRefModifierCodeFixTitle {

--- a/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/Analyzers.CodeFixes/CodeFixResources.resx
@@ -133,4 +133,7 @@
     <value>Replace an out parameter with the return value..</value>
     <comment>The title of the code fix.</comment>
   </data>
+  <data name="RedundantConvertCodeFixTitle" xml:space="preserve">
+    <value>Remove redundant Convert.To method</value>
+  </data>
 </root>

--- a/src/Analyzers/Analyzers.CodeFixes/RedundantConvertCodeFixProvider .cs
+++ b/src/Analyzers/Analyzers.CodeFixes/RedundantConvertCodeFixProvider .cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Acnutech.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RedundantConvertCodeFixProvider)), Shared]
+    public sealed class RedundantConvertCodeFixProvider : CodeFixProvider
+    {
+        public override FixAllProvider GetFixAllProvider()
+        {
+            //Debugger.Launch();
+            // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(RedundantConvertAnalyzer.DiagnosticId);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics[0];
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var invocationExpr = root.FindNode(diagnosticSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
+            if (IsReturnValueUsed(invocationExpr) != true)
+            {
+                // Only offer the code fix if the return value is used.
+                return;
+            }
+
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: CodeFixResources.RedundantConvertCodeFixTitle,
+                    createChangedSolution:
+                        async c => await RemoveRedundantConvertCall(context.Document, invocationExpr, c),
+                    equivalenceKey: nameof(CodeFixResources.RedundantConvertCodeFixTitle)),
+                diagnostic);
+        }
+
+        private async Task<Solution> RemoveRedundantConvertCall(Document document, InvocationExpressionSyntax invocationExpr, CancellationToken c)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, default);
+            var argument = invocationExpr.ArgumentList.Arguments[0];
+            var updatedExpression = argument.Expression
+                .WithLeadingTrivia(invocationExpr.GetLeadingTrivia()
+                    .AddRange(invocationExpr.ArgumentList.OpenParenToken.TrailingTrivia)
+                    .AddRange(argument.GetLeadingTrivia()))
+                .WithTrailingTrivia(argument.GetTrailingTrivia()
+                    .AddRange(invocationExpr.ArgumentList.CloseParenToken.LeadingTrivia)
+                    .AddRange(invocationExpr.GetTrailingTrivia()));
+            editor.ReplaceNode(invocationExpr, updatedExpression);
+            return editor.GetChangedDocument().Project.Solution;
+        }
+
+        private static bool? IsReturnValueUsed(InvocationExpressionSyntax invocationExpr)
+        {
+            var parent = invocationExpr.Parent;
+            if (parent is ExpressionStatementSyntax statementSyntax && statementSyntax.Expression == invocationExpr)
+            {
+                // The invocation is a standalone statement, so its return value is not used.
+                return false;
+            }
+
+            switch (parent)
+            {
+                case ArgumentSyntax _:
+                case EqualsValueClauseSyntax _:
+                case ReturnStatementSyntax _:
+                case BinaryExpressionSyntax _:
+                case ParenthesizedExpressionSyntax _:
+                case MemberAccessExpressionSyntax _:
+                case ConditionalExpressionSyntax _:
+                case ConditionalAccessExpressionSyntax conditionalAccess
+                    when conditionalAccess.Expression == invocationExpr:
+                    return true;
+                default:
+                    // Unable to determine usage; return null
+                    return default;
+            }
+        }
+    }
+}

--- a/src/Analyzers/Analyzers.Test/RedundantConvertAnalyzerTests.cs
+++ b/src/Analyzers/Analyzers.Test/RedundantConvertAnalyzerTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifRedundantConvert = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Acnutech.Analyzers.RedundantConvertAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Acnutech.Analyzers.Test;
+
+[TestClass]
+public class RedundantConvertAnalyzerTests
+{
+    [TestMethod]
+    public async Task EmptyFile_IsIgnored()
+    {
+        var source = @"";
+
+        await VerifRedundantConvert.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ReportsDiagnostic_ForRedundantConvertToInt32()
+    {
+        var source = /* lang=c#-test */"""
+            class Test
+            {
+                void MethodA() {
+                    var a = {|#0:System.Convert.ToInt32|}(4);
+                }
+            }
+            """;
+
+        var expected = VerifRedundantConvert.Diagnostic(RedundantConvertAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("ToInt32", "int");
+        await VerifRedundantConvert.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod]
+    public async Task ReportsDiagnostic_ForRedundantConvertToDouble_LiteralArgument()
+    {
+        var source = /* lang=c#-test */"""
+            using System;
+            class Test
+            {
+                void MethodA() {
+                    var a = {|#0:Convert.ToDouble|}(3.0);
+                }
+            }
+            """;
+
+        var expected = VerifRedundantConvert.Diagnostic(RedundantConvertAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("ToDouble", "double");
+        await VerifRedundantConvert.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod]
+    public async Task ReportsDiagnostic_ForRedundantConvertToDouble_ExpressionArgument()
+    {
+        var source = /* lang=c#-test */"""
+            using System;
+            class Test
+            {
+                void MethodA() {
+                    var a = 3.0;
+                    var b = {|#0:Convert.ToDouble|}(a + 3);
+                }
+            }
+            """;
+
+        var expected = VerifRedundantConvert.Diagnostic(RedundantConvertAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("ToDouble", "double");
+        await VerifRedundantConvert.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [TestMethod]
+    public async Task DoesNotReportDiagnostic_ForConvertToDouble_WithNonRedundantArgument()
+    {
+        var source = /* lang=c#-test */"""
+            using System;
+            class Test
+            {
+                void MethodA() {
+                    var a = Convert.ToDouble(5);
+                }
+            }
+            """;
+
+        await VerifRedundantConvert.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task DoesNotReportDiagnostic_ForConvertToString_WithNullArgument()
+    {
+        var source = /* lang=c#-test */"""
+            using System;
+            class Test
+            {
+                void MethodA() {
+                    var a = Convert.ToString(null);
+                }
+            }
+            """;
+
+        await VerifRedundantConvert.VerifyAnalyzerAsync(source);
+    }
+}

--- a/src/Analyzers/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,5 +2,6 @@
 
 Rule ID  | Category | Severity | Notes
 ---------|----------|----------|--------------------
+ACNU0005 |  Usage   |  Info    | Do not use redundant Convert, [Documentation](https://github.com/acnutech/Analyzers/wiki/ACNU0005
 ACNU0011 |  Usage   |  Info    | Prefer returning tuples over out parameters in void methods, [Documentation](https://github.com/acnutech/Analyzers/wiki/ACNU0011)
 

--- a/src/Analyzers/Analyzers/RedundantConvertAnalyzer.cs
+++ b/src/Analyzers/Analyzers/RedundantConvertAnalyzer.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acnutech.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class RedundantConvertAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "ACNU0005";
+
+        private static readonly LocalizableString Title = GetLocalizableString(nameof(Resources.RedundantConvertDiagnostic_Title));
+        private static readonly LocalizableString MessageFormat = GetLocalizableString(nameof(Resources.RedundantConvertDiagnostic_MessageFormat));
+        private static readonly LocalizableString Description = GetLocalizableString(nameof(Resources.RedundantConvertDiagnostic_Description));
+
+        private const string Category = "Usage";
+
+        internal static readonly DiagnosticDescriptor Rule
+            = new DiagnosticDescriptor(
+                DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true,
+                description: Description, helpLinkUri: "https://github.com/acnutech/Analyzers/wiki/ACNU0005");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            // TODO: Consider registering other actions that act on syntax instead of or in addition to symbols
+            // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+            context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
+        }
+
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax)context.Node;
+            var semanticModel = context.SemanticModel;
+
+            var methodSymbol = semanticModel.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
+            if (methodSymbol == null)
+            {
+                return;
+            }
+
+            if (methodSymbol.ContainingType.ToDisplayString() != "System.Convert")
+            {
+                return;
+            }
+
+            if (!methodSymbol.Name.StartsWith("To", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (invocationExpression.ArgumentList.Arguments.Count != 1)
+            {
+                return;
+            }
+
+            var argument = invocationExpression.ArgumentList.Arguments[0];
+            if (argument == null)
+            {
+                return;
+            }
+
+            var argumentType = semanticModel.GetTypeInfo(argument.Expression);
+            if (argumentType.Type == null)
+            {
+                return;
+            }
+
+            if (!SymbolEqualityComparer.Default.Equals(argumentType.Type, methodSymbol.ReturnType))
+            {
+                return;
+            }
+
+            var diagnostic = Diagnostic.Create(Rule, invocationExpression.Expression.GetLocation(), methodSymbol.Name, argumentType.Type.ToDisplayString());
+            context.ReportDiagnostic(diagnostic);
+        }
+
+        private static LocalizableResourceString GetLocalizableString(string name)
+            => new LocalizableResourceString(name, Resources.ResourceManager, typeof(Resources));
+    }
+}

--- a/src/Analyzers/Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/Analyzers/Resources.Designer.cs
@@ -194,5 +194,32 @@ namespace Acnutech.Analyzers {
                 return ResourceManager.GetString("OutParameterToReturnDiagnostic_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Detects and flags calls to System.Convert.To methods where the argument&apos;s type is already the same as the method&apos;s return type. Such conversions are redundant and can be safely removed, simplifying the code and slightly improving performance..
+        /// </summary>
+        internal static string RedundantConvertDiagnostic_Description {
+            get {
+                return ResourceManager.GetString("RedundantConvertDiagnostic_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The call to Convert.{0} is redundant. The argument&apos;s type is already {1}.
+        /// </summary>
+        internal static string RedundantConvertDiagnostic_MessageFormat {
+            get {
+                return ResourceManager.GetString("RedundantConvertDiagnostic_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove redundant usage of Convert.{0}.
+        /// </summary>
+        internal static string RedundantConvertDiagnostic_Title {
+            get {
+                return ResourceManager.GetString("RedundantConvertDiagnostic_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Analyzers/Analyzers/Resources.resx
+++ b/src/Analyzers/Analyzers/Resources.resx
@@ -177,4 +177,15 @@
     <value>Modern C# prefers tuple returns over out parameters for multiple return values. This makes the method signature clearer and allows for inline tuple deconstruction.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
+  <data name="RedundantConvertDiagnostic_Title" xml:space="preserve">
+    <value>Remove redundant usage of Convert.{0}</value>
+    <comment>{0} - Method name (e.g. ToInt32)</comment>
+  </data>
+  <data name="RedundantConvertDiagnostic_MessageFormat" xml:space="preserve">
+    <value>The call to Convert.{0} is redundant. The argument's type is already {1}</value>
+    <comment>{0} - Method name (e.g. ToInt32), {1} - the type name (e.g. int)</comment>
+  </data>
+  <data name="RedundantConvertDiagnostic_Description" xml:space="preserve">
+    <value>Detects and flags calls to System.Convert.To methods where the argument's type is already the same as the method's return type. Such conversions are redundant and can be safely removed, simplifying the code and slightly improving performance.</value>
+  </data>
 </root>


### PR DESCRIPTION
The analyzer finds all cases where the type of the result is the same as the type of the argument of the Convert.To* method. A code fix is offered to remove the call excluding cases when the result is not used. Then leaving the argument by itself could create an invalid code. The other option is to discard the argument by assigning it to `_`, but leaving it for a manual check seems a better option.